### PR TITLE
Fix loader flicker on weather page

### DIFF
--- a/app/[lng]/weather/components/weather-fetcher.tsx
+++ b/app/[lng]/weather/components/weather-fetcher.tsx
@@ -137,8 +137,11 @@ const WeatherFetcher: FC<WeatherFetcherProps> = ({ locales }) => {
     />
   }
 
-  if (isLoadingPosition) {
-    return <LoadingIndicator label="Getting geolocation..." />;
+  const isFetching = isLoadingPosition || weatherLoading || (!weather && !weatherError && !geoError)
+
+  if (isFetching) {
+    const label = isLoadingPosition ? "Getting geolocation..." : "Getting weather..."
+    return <LoadingIndicator label={label} />
   }
 
   if (geoError) {
@@ -152,10 +155,6 @@ const WeatherFetcher: FC<WeatherFetcherProps> = ({ locales }) => {
         setLocationManualVisible(true)
       }}
     />
-  }
-
-  if (weatherLoading) {
-    return <LoadingIndicator label="Getting weather..." />;
   }
 
   if (weatherError) {


### PR DESCRIPTION
## Summary
- ensure loading indicator stays visible until geolocation and weather data finish

## Testing
- `npx jest --runInBand --passWithNoTests` *(fails: jest not installed)*