### PR TITLE
Add basic sign in page

### DIFF
--- a/app/[lng]/user/signin/layout.tsx
+++ b/app/[lng]/user/signin/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import { metadataTranslation } from '../../../i18n'
+
+export async function generateMetadata({ params: { lng } }: { params: { lng: string } }): Promise<Metadata> {
+  const { t } = await metadataTranslation(lng, 'signin')
+  const title = t('meta-title')
+  const description = t('meta-description')
+  const metadataBase = new URL('https://www.borinorge.no')
+
+  const metadata: Metadata = {
+    title,
+    description,
+    metadataBase,
+    openGraph: {
+      type: 'website',
+      url: '@site',
+      title,
+      description,
+      siteName: title,
+    },
+    twitter: {
+      card: 'summary',
+      site: '@site',
+      creator: '@creator',
+    },
+  }
+
+  return metadata
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/[lng]/user/signin/page.tsx
+++ b/app/[lng]/user/signin/page.tsx
@@ -1,0 +1,31 @@
+import { greatVibes } from '../../../fonts'
+import { useTranslation } from '../../../i18n'
+import { Breadcrumbs } from '../../components/breadcrumbs'
+import { Footer } from '../../components/footer'
+import SignInForm from './signin-form'
+
+export default async function SignIn({ params: { lng } }: { params: { lng: string } }) {
+  const { t } = await useTranslation(lng, 'signin')
+
+  return (
+    <>
+      <header className="header">
+        <div className="header__container">
+          <h1 className={`header__title header__title--home ${greatVibes.variable}`}>{t('title')}</h1>
+        </div>
+      </header>
+      <main className="project">
+        <Breadcrumbs currentPage={t('title')} lng={lng} path={`user/signin`} />
+        <SignInForm
+          lng={lng}
+          labels={{
+            username: t('username'),
+            password: t('password'),
+            submit: t('submit'),
+          }}
+        />
+      </main>
+      <Footer lng={lng} />
+    </>
+  )
+}

--- a/app/[lng]/user/signin/signin-form.tsx
+++ b/app/[lng]/user/signin/signin-form.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface Labels {
+  username: string
+  password: string
+  submit: string
+}
+
+export default function SignInForm({ lng, labels }: { lng: string; labels: Labels }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const router = useRouter()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('authorized', 'true')
+    }
+    router.push(`/${lng}`)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        type="text"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        className="input input-bordered border-2 rounded-md border-gray-500 w-full p-2 text-gray-600"
+        placeholder={labels.username}
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="input input-bordered border-2 rounded-md border-gray-500 w-full p-2 text-gray-600"
+        placeholder={labels.password}
+      />
+      <button type="submit" className="target-action__link">
+        {labels.submit}
+      </button>
+    </form>
+  )
+}

--- a/app/i18n/locales/en/signin.json
+++ b/app/i18n/locales/en/signin.json
@@ -1,0 +1,8 @@
+{
+  "meta-title": "Borinorge — Sign in",
+  "meta-description": "Sign in to Vi bor i Norge",
+  "title": "Sign in",
+  "username": "Username",
+  "password": "Password",
+  "submit": "Sign in"
+}

--- a/app/i18n/locales/nb/signin.json
+++ b/app/i18n/locales/nb/signin.json
@@ -1,0 +1,8 @@
+{
+  "meta-title": "Borinorge — Logg inn",
+  "meta-description": "Logg inn på Vi bor i Norge",
+  "title": "Logg inn",
+  "username": "Brukernavn",
+  "password": "Passord",
+  "submit": "Logg inn"
+}

--- a/app/i18n/locales/nn/signin.json
+++ b/app/i18n/locales/nn/signin.json
@@ -1,0 +1,8 @@
+{
+  "meta-title": "Borinorge — Logg inn",
+  "meta-description": "Logg inn på Vi bur i Noreg",
+  "title": "Logg inn",
+  "username": "Brukarnamn",
+  "password": "Passord",
+  "submit": "Logg inn"
+}

--- a/app/i18n/locales/ru/signin.json
+++ b/app/i18n/locales/ru/signin.json
@@ -1,0 +1,8 @@
+{
+  "meta-title": "Borinorge — Вход",
+  "meta-description": "Войдите на сайт Vi bor i Norge",
+  "title": "Вход",
+  "username": "Имя пользователя",
+  "password": "Пароль",
+  "submit": "Войти"
+}

--- a/app/i18n/locales/uk/signin.json
+++ b/app/i18n/locales/uk/signin.json
@@ -1,0 +1,8 @@
+{
+  "meta-title": "Borinorge — Вхід",
+  "meta-description": "Увійдіть на Vi bor i Norge",
+  "title": "Вхід",
+  "username": "Ім'я користувача",
+  "password": "Пароль",
+  "submit": "Увійти"
+}


### PR DESCRIPTION
## Summary
- add basic `/${lng}/user/signin` page
- include SignInForm client component
- supply translations for sign in page in all languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68641af091008324b4174f096d411c55