### PR TITLE
Implement user profile page

### DIFF
--- a/app/[lng]/user/profile/page.tsx
+++ b/app/[lng]/user/profile/page.tsx
@@ -1,0 +1,27 @@
+import { greatVibes } from '../../../fonts'
+import { useTranslation } from '../../../i18n'
+import { Breadcrumbs } from '../../components/breadcrumbs'
+import { Footer } from '../../components/footer'
+import SignOutButton from './signout-button'
+
+export default async function Profile({ params: { lng } }: { params: { lng: string } }) {
+  const { t } = await useTranslation(lng)
+
+  return (
+    <>
+      <header className="header">
+        <div className="header__container">
+          <h1 className={`header__title header__title--home ${greatVibes.variable}`}>{t('user.profile.title')}</h1>
+        </div>
+      </header>
+      <main className="project">
+        <Breadcrumbs currentPage={t('user.profile.title')} lng={lng} path={`user/profile`} />
+        <p className="project__paragraph">{t('coming-soon')}</p>
+        <div className='target-action'>
+          <SignOutButton label={t('user.profile.sign-out')} lng={lng} />
+        </div>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/app/[lng]/user/profile/signout-button.tsx
+++ b/app/[lng]/user/profile/signout-button.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+export default function SignOutButton({ label, lng }: { label: string, lng: string }) {
+  const handleClick = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('authorized', 'false')
+      window.location.href = `/${lng}`
+    }
+  }
+
+  return (
+    <button onClick={handleClick} className='target-action__link'>
+      {label}
+    </button>
+  )
+}

--- a/app/i18n/locales/en/translation.json
+++ b/app/i18n/locales/en/translation.json
@@ -238,5 +238,12 @@
     "weather_data": "Weather data",
     "icons": "Icons",
     "under_the": "under the"
+  },
+  "user": {
+    "profile": {
+      "meta-title": "Borinorge — Profile",
+      "title": "User profile",
+      "sign-out": "Sign out"
+    }
   }
 }

--- a/app/i18n/locales/nb/translation.json
+++ b/app/i18n/locales/nb/translation.json
@@ -238,5 +238,12 @@
     "weather_data": "Værdata",
     "icons": "Ikoner",
     "under_the": "under"
+  },
+  "user": {
+    "profile": {
+      "meta-title": "Borinorge — Profil",
+      "title": "Brukerprofil",
+      "sign-out": "Logg ut"
+    }
   }
 }

--- a/app/i18n/locales/nn/translation.json
+++ b/app/i18n/locales/nn/translation.json
@@ -238,5 +238,12 @@
     "weather_data": "Verdata",
     "icons": "Ikon",
     "under_the": "under"
+  },
+  "user": {
+    "profile": {
+      "meta-title": "Borinorge — Profil",
+      "title": "Brukarprofil",
+      "sign-out": "Logg ut"
+    }
   }
 }

--- a/app/i18n/locales/ru/translation.json
+++ b/app/i18n/locales/ru/translation.json
@@ -238,5 +238,12 @@
     "weather_data": "Данные о погоде",
     "icons": "Иконки",
     "under_the": "на условиях"
+  },
+  "user": {
+    "profile": {
+      "meta-title": "Borinorge — Профиль",
+      "title": "Профиль пользователя",
+      "sign-out": "Выйти"
+    }
   }
 }

--- a/app/i18n/locales/uk/translation.json
+++ b/app/i18n/locales/uk/translation.json
@@ -238,5 +238,12 @@
     "weather_data": "Дані про погоду",
     "icons": "Іконки",
     "under_the": "на умовах"
+  },
+  "user": {
+    "profile": {
+      "meta-title": "Borinorge — Профіль",
+      "title": "Профіль користувача",
+      "sign-out": "Вийти"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add `/[lng]/user/profile` page with sign-out button
- provide sign out functionality via local storage
- add translation strings for the new page in all languages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68641ae711e88324848de267ec8366d5