### PR TITLE
Add signup page

### DIFF
--- a/app/[lng]/user/signup/layout.tsx
+++ b/app/[lng]/user/signup/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import { metadataTranslation } from '../../../i18n'
+
+export async function generateMetadata({ params: { lng } }: { params: { lng: string } }): Promise<Metadata> {
+  const { t } = await metadataTranslation(lng, 'signup')
+  const title = t('meta-title')
+  const description = t('meta-description')
+  const metadataBase = new URL('https://www.borinorge.no')
+
+  const metadata: Metadata = {
+    title,
+    description,
+    metadataBase,
+    openGraph: {
+      type: 'website',
+      url: '@site',
+      title,
+      description,
+      siteName: title,
+    },
+    twitter: {
+      card: 'summary',
+      site: '@site',
+      creator: '@creator',
+    },
+  }
+
+  return metadata
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/[lng]/user/signup/page.tsx
+++ b/app/[lng]/user/signup/page.tsx
@@ -1,0 +1,37 @@
+import { greatVibes } from '../../../fonts'
+import { useTranslation } from '../../../i18n'
+import { Breadcrumbs } from '../../components/breadcrumbs'
+import { Footer } from '../../components/footer'
+import SignUpForm from './signup-form'
+import Link from 'next/link'
+
+export default async function SignUp({ params: { lng } }: { params: { lng: string } }) {
+  const { t } = await useTranslation(lng, 'signup')
+
+  return (
+    <>
+      <header className="header">
+        <div className="header__container">
+          <h1 className={`header__title header__title--home ${greatVibes.variable}`}>{t('title')}</h1>
+        </div>
+      </header>
+      <main className="project">
+        <Breadcrumbs currentPage={t('title')} lng={lng} path={`user/signup`} />
+        <SignUpForm
+          lng={lng}
+          labels={{
+            username: t('username'),
+            password: t('password'),
+            submit: t('submit'),
+          }}
+        />
+        <div className="target-action mt-4">
+          <Link href={`/${lng}/user/signin`} className="target-action__link">
+            {t('sign-in')}
+          </Link>
+        </div>
+      </main>
+      <Footer lng={lng} />
+    </>
+  )
+}

--- a/app/[lng]/user/signup/signup-form.tsx
+++ b/app/[lng]/user/signup/signup-form.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+interface Labels {
+  username: string
+  password: string
+  submit: string
+}
+
+export default function SignUpForm({ lng, labels }: { lng: string; labels: Labels }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const router = useRouter()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('authorized', 'true')
+    }
+    router.push(`/${lng}`)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        type="text"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        className="input input-bordered border-2 rounded-md border-gray-500 w-full p-2 text-gray-600"
+        placeholder={labels.username}
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="input input-bordered border-2 rounded-md border-gray-500 w-full p-2 text-gray-600"
+        placeholder={labels.password}
+      />
+      <button type="submit" className="target-action__link">
+        {labels.submit}
+      </button>
+    </form>
+  )
+}

--- a/app/i18n/locales/en/signup.json
+++ b/app/i18n/locales/en/signup.json
@@ -1,0 +1,9 @@
+{
+  "meta-title": "Borinorge — Sign up",
+  "meta-description": "Create an account on Vi bor i Norge",
+  "title": "Sign up",
+  "username": "Username",
+  "password": "Password",
+  "submit": "Sign up",
+  "sign-in": "Already registered? Sign in"
+}

--- a/app/i18n/locales/nb/signup.json
+++ b/app/i18n/locales/nb/signup.json
@@ -1,0 +1,9 @@
+{
+  "meta-title": "Borinorge — Registrer deg",
+  "meta-description": "Registrer deg på Vi bor i Norge",
+  "title": "Registrer deg",
+  "username": "Brukernavn",
+  "password": "Passord",
+  "submit": "Registrer deg",
+  "sign-in": "Allerede registrert? Logg inn"
+}

--- a/app/i18n/locales/nn/signup.json
+++ b/app/i18n/locales/nn/signup.json
@@ -1,0 +1,9 @@
+{
+  "meta-title": "Borinorge — Registrer deg",
+  "meta-description": "Registrer deg på Vi bur i Noreg",
+  "title": "Registrer deg",
+  "username": "Brukarnamn",
+  "password": "Passord",
+  "submit": "Registrer deg",
+  "sign-in": "Allereie registrert? Logg inn"
+}

--- a/app/i18n/locales/ru/signup.json
+++ b/app/i18n/locales/ru/signup.json
@@ -1,0 +1,9 @@
+{
+  "meta-title": "Borinorge — Регистрация",
+  "meta-description": "Зарегистрируйтесь на Vi bor i Norge",
+  "title": "Регистрация",
+  "username": "Имя пользователя",
+  "password": "Пароль",
+  "submit": "Зарегистрироваться",
+  "sign-in": "Уже зарегистрированы? Войдите"
+}

--- a/app/i18n/locales/uk/signup.json
+++ b/app/i18n/locales/uk/signup.json
@@ -1,0 +1,9 @@
+{
+  "meta-title": "Borinorge — Реєстрація",
+  "meta-description": "Зареєструйтеся на Vi bor i Norge",
+  "title": "Реєстрація",
+  "username": "Ім'я користувача",
+  "password": "Пароль",
+  "submit": "Зареєструватися",
+  "sign-in": "Вже зареєстровані? Увійдіть"
+}


### PR DESCRIPTION
## Summary
- add a `/[lng]/user/signup` route with simple form
- provide metadata generator
- localize signup page in all languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686423fec5c08324b3519ab6c6360600